### PR TITLE
add support for smartos with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,26 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-14.04
+  - name: smartos-base-64-14.3.0
+    driver_config:
+      box: livinginthepast/smartos-base64
+      box_url: https://atlas.hashicorp.com/livinginthepast/boxes/smartos-base64
+      vagrantfile_erb: test/templates/Vagrantfile.smartos.erb
+      zone:
+        name: base64-lts
+        brand: joyent
+        image: 62f148f8-6e84-11e4-82c5-efca60348b9f
+    provisioner:
+      require_chef_omnibus: true
+      chef_omnibus_url: https://raw.github.com/wanelo-chef/chef-bootstrap/master/latest.sh
+
+suites:
+  - name: default
+    run_list:
+      - recipe[chef-sbt::default]

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "test-kitchen"
+gem "kitchen-vagrant"
+gem "berkshelf"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: chef-sudo
+# Cookbook Name:: chef-sbt
 # Attribute File:: default
 #
 # Copyright 2013 Matt Farmer
@@ -17,5 +17,13 @@
 # limitations under the License.
 #
 
-default['sbt']['version'] = '0.12.4'
+default['sbt']['version'] = '0.13.8'
 default['sbt']['java_options'] = '-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=512M'
+default['sbt']['java_cookbook'] = 'openjdk'
+
+case node['platform']
+when 'smartos'
+  default['sbt']['path'] = '/opt/local'
+when 'ubuntu'
+	default['sbt']['path'] = '/usr/local'
+end

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,95 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,9 +5,12 @@ license           'Apache 2.0'
 description       'Installs the sbt version you request from manual download.'
 version            '0.0.1'
 
+depends 'java'
+depends 'openjdk'
+
 recipe 'sbt', 'Downloads and installs sbt in your path.'
 
-%w{ubuntu debian}.each do |os|
+%w{ubuntu debian smartos}.each do |os|
   supports os
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,24 +17,25 @@
 # limitations under the License.
 #
 
-remote_file "/usr/local/bin/sbt-launch.jar" do
+include_recipe "#{node[:sbt][:java_cookbook]}"
+
+remote_file "#{node[:sbt][:path]}/bin/sbt-launch.jar" do
   source "http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/#{node[:sbt][:version]}/sbt-launch.jar"
   action :create
+  owner "root"
+  group "root"
+  mode 0755
 
-  not_if "java -jar /usr/local/bin/sbt-launch.jar \"sbt-version\" | tail -1 | awk '{print $2}' | grep '#{node[:sbt][:version]}'"
+  not_if "java -jar #{node[:sbt][:path]}/bin/sbt-launch.jar \"sbt-version\" | tail -1 | awk '{print $2}' | grep '#{node[:sbt][:version]}'"
 end
 
-execute "sudo chown root:root /usr/local/bin/sbt-launch.jar"
-execute "sudo chmod 0755 /usr/local/bin/sbt-launch.jar"
-
-template "/usr/local/bin/sbt" do
+template "#{node[:sbt][:path]}/bin/sbt" do
   source "sbt.erb"
   variables({
     :java_options => node[:sbt][:java_options]
   })
 
   action :create
-
   owner "root"
   group "root"
   mode 0755

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'chefspec'
+require 'chefspec/berkshelf'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: chef-sbt
+# Spec:: default
+#
+# Copyright (c) 2015 The Authors, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'chef-sbt::default' do
+  context 'When all attributes are default, on an unspecified platform' do
+    let(:chef_run) do
+      runner = ChefSpec::ServerRunner.new
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+  end
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+sbt = `which sbt`.strip
+sbt_jar = `which sbt-launch.jar`.strip
+
+describe command("java -jar #{sbt_jar} \"sbt-version\" | tail -1 | awk \'{print $2}\' | grep 0.13.8") do
+  its(:stdout) { should contain('0.13.8') }
+  its(:exit_status) { should eq 0 }
+end
+
+describe file("#{sbt}") do
+	it { should contain 'sbt-launch.jar'}
+end
+
+describe file("#{sbt_jar}") do
+	it { should be_owned_by 'root' }
+	it { should be_grouped_into 'root' }
+	it { should be_mode 755 }
+end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'serverspec'
+
+set :backend, :exec

--- a/test/templates/Vagrantfile.smartos.erb
+++ b/test/templates/Vagrantfile.smartos.erb
@@ -1,0 +1,59 @@
+#!/usr/bin/ruby
+#^ruby syntax highlighting
+
+Vagrant.configure("2") do |c|
+  c.vm.box = "<%= config[:box] %>"
+  c.vm.box_url = "<%= config[:box_url] %>"
+
+  c.ssh.insert_key = false
+
+  <% if config[:zone] %>
+  c.vm.communicator = 'smartos'
+  c.global_zone.platform_image = 'latest'
+  c.zone.name = '<%= config[:zone][:name] %>'
+  c.zone.brand = '<%= config[:zone][:brand] || 'joyent' %>'
+  c.zone.image = '<%= config[:zone][:image] %>'
+  c.zone.memory = 1536
+  c.zone.disk_size = 5
+  <% end %>
+  <% if config[:vm_hostname] %>
+    c.vm.hostname = "<%= config[:vm_hostname] %>"
+  <% end %>
+  <% if config[:guest] %>
+    c.vm.guest = <%= config[:guest] %>
+  <% end %>
+  <% if config[:username] %>
+    c.ssh.username = "<%= config[:username] %>"
+  <% end %>
+  <% if config[:password] %>
+    c.ssh.password = "<%= config[:password] %>"
+  <% end %>
+  <% if config[:ssh_key] %>
+    c.ssh.private_key_path = "<%= config[:ssh_key] %>"
+  <% end %>
+  <% Array(config[:network]).each do |opts| %>
+    c.vm.network(:<%= opts[0] %>, <%= opts[1..-1].join(", ") %>)
+  <% end %>
+  c.vm.synced_folder ".", "/vagrant", disabled: true
+  <% config[:synced_folders].each do |source, destination, options| %>
+    c.vm.synced_folder "<%= source %>", "<%= destination %>", <%= options %>
+  <% end %>
+  c.vm.provider :<%= config[:provider] %> do |p|
+  <% config[:customize].each do |key, value| %>
+    <% case config[:provider]
+    when "virtualbox" %>
+  p.customize ["modifyvm", :id, "--<%= key %>", "<%= value %>"]
+    <% when "rackspace", "softlayer" %>
+      p.<%= key %> = "<%= value%>"
+    <% when /^vmware_/ %>
+      <% if key == :memory %>
+        <% unless config[:customize].include?(:memsize) %>
+          p.vmx["memsize"] = "<%= value %>"
+        <% end %>
+      <% else %>
+        p.vmx["<%= key %>"] = "<%= value %>"
+      <% end %>
+    <% end %>
+  <% end %>
+  end
+end


### PR DESCRIPTION
Hi @farmdawgnation,
Here's a PR adding a lot of Test Kitchen bits as well as SmartOS support to your cookbook. I really like the simplicity of your approach and have tried to stick to it while including some emerging standard practices for cookbooks.

The biggest changes you'll notice is that I'm doing paths in an attribute-driven way and also allowing users to choose between the 'java' and 'openjdk' cookbooks as dependencies via an attribute.

This reason for no longer hardcoding the 'java' dependency is that the big, community 'java' cookbook has issues when run inside containers and also on SmartOS.

Feel free to ask for adjustments or to ask questions.  Thanks again for the initial work.  We hope to start using the code here at yetu starting this week :smiley: 