### PR TITLE
Add support for specifying a checksum for the SBT jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ as well. Haven't done a lot of testing yet.
 
 The chef-sbt cookbook recognizes the following attributes.
 
-* `node['sbt']['version']` - The version of the sbt launcher you would like to use. Currently, this defaults to 0.12.4, the latest stable, but can be any version available in the [typesafe download repo](http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/).
+* `node['sbt']['version']` - The version of the sbt launcher you would like to use. Currently, this defaults to 0.13.8, the latest stable, but can be any version available in the [typesafe download repo](http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/).
+* `node['sbt']['checksum']` - The SHA256 checksum of the file downloaded from Typesafe.com. (optional)
 * `node['sbt']['java_options']` - The JVM flags that should be passed to the JVM when sbt starts. Currently, this is defaulted to `-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=512M`, and that works well for me... but YMMV.
 
 ### Recipes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,7 @@
 #
 
 default['sbt']['version'] = '0.13.8'
+default['sbt']['checksum'] = '6570bb03df6138ffaa7ac0bbe35eb4ea79062d1146b6929c75cf238d14dd9158'
 default['sbt']['java_options'] = '-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=512M'
 default['sbt']['java_cookbook'] = 'openjdk'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,8 @@
 include_recipe "#{node[:sbt][:java_cookbook]}"
 
 remote_file "#{node[:sbt][:path]}/bin/sbt-launch.jar" do
-  source "http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/#{node[:sbt][:version]}/sbt-launch.jar"
+  source "https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/#{node[:sbt][:version]}/sbt-launch.jar"
+  checksum node['sbt']['checksum'] if node['sbt']['checksum']
   action :create
   owner "root"
   group "root"


### PR DESCRIPTION
This is useful when you want to enforce the presence of a checksum in a
remote_file resource.

Also use HTTPS when downloading from typesafe.com, otherwise the checksum is
not so useful.